### PR TITLE
Fix Xcode 13 Beta 3+ usabilitty issue with `UIApplication.shared` property

### DIFF
--- a/Sources/AZTabBarController/AZTabBarController.swift
+++ b/Sources/AZTabBarController/AZTabBarController.swift
@@ -316,7 +316,7 @@ open class AZTabBarController: UIViewController {
     fileprivate lazy var buttonsColors: [UIColor?] = Array<UIColor?>(repeating: nil,count: self.tabCount)
 
     fileprivate var isRTL: Bool {
-        return UIApplication.shared.userInterfaceLayoutDirection == UIUserInterfaceLayoutDirection.rightToLeft
+        UIView.userInterfaceLayoutDirection(for: view.semanticContentAttribute) == .rightToLeft
     }
     
     /*


### PR DESCRIPTION
This is a workaround for Xcode 13 Beta 3+ issue which forbids usage of `UIApplication.shared` property within iOS Application Extensions. I am suggesting to use `UIView.userInterfaceLayoutDirection(for: ...)` alternative here as a fix. Since that method is available starting from iOS 9 it should not affect our dependent projects.